### PR TITLE
Link cli.nylas.com guides under CLI bash blocks

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -22,7 +22,7 @@ brew install nylas/nylas-cli/nylas
 nylas init
 ```
 
-Then pick a quickstart for your stack — see below.
+More options in the [CLI getting-started guide](https://cli.nylas.com/guides/getting-started). Then pick a quickstart for your stack — see below.
 
 ## Quickstarts — pick your stack
 
@@ -122,6 +122,8 @@ Windsurf, or VS Code:
 brew install nylas/nylas-cli/nylas
 nylas mcp install
 ```
+
+Walkthrough: [give AI agents email access via MCP](https://cli.nylas.com/guides/give-ai-agents-email-access-via-mcp).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
Adds two inline deep links to cli.nylas.com from the spots where readers
have just run a CLI command and might want to know more.

- **Get started** — link to [the CLI getting-started guide](https://cli.nylas.com/guides/getting-started) under the \`nylas init\` block.
- **AI agents** — link to [give AI agents email access via MCP](https://cli.nylas.com/guides/give-ai-agents-email-access-via-mcp) under the \`nylas mcp install\` block.

\`[CLI docs](https://cli.nylas.com)\` was already in the header nav row from the prior refresh — left as-is.

## Test plan
- [ ] Preview the rendered profile, click both new links, confirm they land on the right pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)